### PR TITLE
feat: add JSON format endpoint with comprehensive tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,4 +38,6 @@ def format_json(request: JsonFormatRequest):
         formatted_json = json.dumps(parsed_json, indent=2, ensure_ascii=False)
         return {"formatted": formatted_json}
     except json.JSONDecodeError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid JSON string: {str(e)}")
+        raise HTTPException(
+            status_code=400, detail=f"Invalid JSON string: {str(e)}"
+        ) from e

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,17 @@
 """FastAPI application main module."""
 
+import json
+
 from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 
 app = FastAPI()
+
+
+class JsonFormatRequest(BaseModel):
+    """Request model for JSON formatting."""
+
+    json_string: str
 
 
 @app.get("/")
@@ -17,3 +26,16 @@ def divide(a: float, b: float):
     if b == 0:
         raise HTTPException(status_code=400, detail="Division by zero is not allowed")
     return {"result": a / b}
+
+
+@app.post("/format")
+def format_json(request: JsonFormatRequest):
+    """Format a JSON string in a human-readable way."""
+    try:
+        # Parse the JSON string
+        parsed_json = json.loads(request.json_string)
+        # Format it with proper indentation
+        formatted_json = json.dumps(parsed_json, indent=2, ensure_ascii=False)
+        return {"formatted": formatted_json}
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON string: {str(e)}")

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -29,6 +29,57 @@ class TestMain(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"result": 3.0})
 
+    def test_format_json_valid(self):
+        """Test formatting a valid JSON string."""
+        json_string = '{"name":"John","age":30,"city":"New York"}'
+        response = self.client.post("/format", json={"json_string": json_string})
+        self.assertEqual(response.status_code, 200)
+        expected_formatted = (
+            '{\n  "name": "John",\n  "age": 30,\n  "city": "New York"\n}'
+        )
+        self.assertEqual(response.json()["formatted"], expected_formatted)
+
+    def test_format_json_nested(self):
+        """Test formatting a nested JSON string."""
+        json_string = '{"user":{"name":"Alice","details":{"age":25,"skills":["Python","FastAPI"]}}}'
+        response = self.client.post("/format", json={"json_string": json_string})
+        self.assertEqual(response.status_code, 200)
+        result = response.json()["formatted"]
+        # Check that it's properly formatted (contains newlines and proper indentation)
+        self.assertIn("\n", result)
+        self.assertIn('  "user":', result)
+        self.assertIn('    "name": "Alice"', result)
+
+    def test_format_json_array(self):
+        """Test formatting a JSON array."""
+        json_string = '[{"id":1,"name":"Item1"},{"id":2,"name":"Item2"}]'
+        response = self.client.post("/format", json={"json_string": json_string})
+        self.assertEqual(response.status_code, 200)
+        result = response.json()["formatted"]
+        self.assertIn("[\n", result)
+        self.assertIn("  {\n", result)
+
+    def test_format_json_invalid(self):
+        """Test formatting an invalid JSON string."""
+        json_string = '{"name":"John","age":30,}'  # Trailing comma makes it invalid
+        response = self.client.post("/format", json={"json_string": json_string})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid JSON string", response.json()["detail"])
+
+    def test_format_json_empty_string(self):
+        """Test formatting an empty string."""
+        json_string = ""
+        response = self.client.post("/format", json={"json_string": json_string})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid JSON string", response.json()["detail"])
+
+    def test_format_json_malformed(self):
+        """Test formatting a malformed JSON string."""
+        json_string = '{"name": "John", "age": 30'  # Missing closing brace
+        response = self.client.post("/format", json={"json_string": json_string})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid JSON string", response.json()["detail"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Add new /format POST endpoint that takes a JSON string and returns it formatted
- Implement JsonFormatRequest Pydantic model for request validation
- Add proper error handling for invalid JSON with descriptive error messages
- Include comprehensive test suite covering:
  - Valid JSON formatting (simple, nested, arrays)
  - Error handling (invalid JSON, empty strings, malformed JSON)
- All tests passing (10 total tests)

The endpoint accepts JSON strings and returns them with proper indentation for improved readability, useful for debugging and development workflows.